### PR TITLE
Implement routing endpoints for various categories

### DIFF
--- a/all-a-board/package-lock.json
+++ b/all-a-board/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^0.27.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -8437,6 +8438,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -13928,6 +13937,30 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -22716,6 +22749,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -26502,6 +26543,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/all-a-board/package.json
+++ b/all-a-board/package.json
@@ -9,6 +9,7 @@
     "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/all-a-board/public/index.html
+++ b/all-a-board/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>All A-Board</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/all-a-board/src/App.js
+++ b/all-a-board/src/App.js
@@ -1,18 +1,31 @@
-import './App.css';
-import { useState } from 'react';
-import Header from './components/Header/Header';
-import Main from './components/Main/Main';
-import Footer from './components/Footer/Footer';
+import './App.css'
+import { useState, useEffect } from 'react'
+import { getCategories } from './axios'
+import {BrowserRouter, Routes, Route, Navigate} from 'react-router-dom'
+import Header from './components/Header/Header'
+import Main from './components/Main/Main'
+import Footer from './components/Footer/Footer'
 
 function App() {
   const [currentPage, setCurrentPage] = useState(1) 
 
   return (
+    <BrowserRouter>
     <div className="App">
       <Header />
-      <Main currentPage={currentPage}/>
+      <Routes>
+        <Route path={'/'} element={<Main currentPage={currentPage}/>}/>
+        <Route path={'/strategy'} element={<Main currentPage={currentPage} category='strategy'/>}/>
+        <Route path={'/hidden-roles'} element={<Main currentPage={currentPage} category='hidden-roles'/>}/>
+        <Route path={'/dexterity'} element={<Main currentPage={currentPage} category='dexterity'/>}/>
+        <Route path={'/push-your-luck'} element={<Main currentPage={currentPage} category='push-your-luck'/>}/>
+        <Route path={'/roll-and-write'} element={<Main currentPage={currentPage} category='roll-and-write'/>}/>
+        <Route path={'/deck-building'} element={<Main currentPage={currentPage} category='deck-building'/>}/>
+        <Route path={'/engine-building'} element={<Main currentPage={currentPage} category='engine-building'/>}/>
+      </Routes>
       <Footer />
     </div>
+    </BrowserRouter>
   );
 }
 

--- a/all-a-board/src/App.js
+++ b/all-a-board/src/App.js
@@ -1,7 +1,7 @@
 import './App.css'
 import { useState, useEffect } from 'react'
 import { getCategories } from './axios'
-import {BrowserRouter, Routes, Route, Navigate} from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import Header from './components/Header/Header'
 import Main from './components/Main/Main'
 import Footer from './components/Footer/Footer'
@@ -12,16 +12,10 @@ function App() {
   return (
     <BrowserRouter>
     <div className="App">
-      <Header />
+      <Header/>
       <Routes>
         <Route path={'/'} element={<Main currentPage={currentPage}/>}/>
-        <Route path={'/strategy'} element={<Main currentPage={currentPage} category='strategy'/>}/>
-        <Route path={'/hidden-roles'} element={<Main currentPage={currentPage} category='hidden-roles'/>}/>
-        <Route path={'/dexterity'} element={<Main currentPage={currentPage} category='dexterity'/>}/>
-        <Route path={'/push-your-luck'} element={<Main currentPage={currentPage} category='push-your-luck'/>}/>
-        <Route path={'/roll-and-write'} element={<Main currentPage={currentPage} category='roll-and-write'/>}/>
-        <Route path={'/deck-building'} element={<Main currentPage={currentPage} category='deck-building'/>}/>
-        <Route path={'/engine-building'} element={<Main currentPage={currentPage} category='engine-building'/>}/>
+        <Route path={'/:category'} element={<Main currentPage={currentPage}/>}/>
       </Routes>
       <Footer />
     </div>

--- a/all-a-board/src/components/Header/Header.jsx
+++ b/all-a-board/src/components/Header/Header.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function Header() {
-    return <header><h1>All A-Board</h1></header>
+    return <header><h1><Link to='../' replace>All A-Board</Link></h1></header>
 }

--- a/all-a-board/src/components/Main/Main.css
+++ b/all-a-board/src/components/Main/Main.css
@@ -1,0 +1,15 @@
+nav ul {
+    padding: 0;
+    list-style: none;
+}
+
+li a {
+    text-decoration: none;
+    color: black
+}
+
+li a:hover {
+    text-decoration: none;
+    color: blue;
+    font-style: italic;
+}

--- a/all-a-board/src/components/Main/Main.jsx
+++ b/all-a-board/src/components/Main/Main.jsx
@@ -1,26 +1,33 @@
 import {useState, useEffect} from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { getCategories, getReviews } from '../../axios'
 import ReviewCard from './ReviewCard'
 
-export default function Main({currentPage}) {
+export default function Main({currentPage, category}) {
     const [reviews, setReviews] = useState([])
     const [selectedReview, setSelectedReview] = useState()
-    const [categories, setCategories] = useState([])
-    const [category, setCategory] = useState()
     const [sortBy, setSortBy] = useState()
     const [order, setOrder] = useState()
+    const [categories, setCategories] = useState([])
+    const navigate = useNavigate()
+    const location = useLocation()
 
     useEffect(() => {
         getCategories().then(({data}) => setCategories(data))
     }, [])
-
+  
     useEffect(() => {
         getReviews(currentPage, category, sortBy, order).then(({data}) => setReviews(data))
     }, [currentPage, category, sortBy, order])
 
+    function handleCategory(e) {
+        const category = e.target.value
+        navigate(`../${e.target.value}`, {replace: true})
+    }
+
     return <main>
         <label htmlFor="category-select">Category: </label>
-        <select onChange={e => setCategory(e.target.value)} name="category" id="category-select">
+        <select onChange={handleCategory} name="category" id="category-select">
         <option value="">Show All</option>
         {categories.map((category) => {
             return <option key={category.slug} value={category.slug}>{category.slug}</option>
@@ -28,7 +35,7 @@ export default function Main({currentPage}) {
         </select>
         <section>
             {reviews.map(review => {
-                return <ReviewCard title={review.title} imageURL={review.review_img_url} category={review.category} author={review.owner}/>
+                return <ReviewCard key={review.review_id} title={review.title} imageURL={review.review_img_url} category={review.category} author={review.owner}/>
             })}
         </section>
         

--- a/all-a-board/src/components/Main/Main.jsx
+++ b/all-a-board/src/components/Main/Main.jsx
@@ -1,16 +1,19 @@
+import './Main.css'
 import {useState, useEffect} from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useParams, Link } from 'react-router-dom'
 import { getCategories, getReviews } from '../../axios'
 import ReviewCard from './ReviewCard'
+import ReviewPage from './ReviewPage'
 
-export default function Main({currentPage, category}) {
+export default function Main({currentPage}) {
     const [reviews, setReviews] = useState([])
     const [selectedReview, setSelectedReview] = useState()
     const [sortBy, setSortBy] = useState()
     const [order, setOrder] = useState()
     const [categories, setCategories] = useState([])
     const navigate = useNavigate()
-    const location = useLocation()
+
+    const {category} = useParams()
 
     useEffect(() => {
         getCategories().then(({data}) => setCategories(data))
@@ -20,24 +23,25 @@ export default function Main({currentPage, category}) {
         getReviews(currentPage, category, sortBy, order).then(({data}) => setReviews(data))
     }, [currentPage, category, sortBy, order])
 
-    function handleCategory(e) {
-        const category = e.target.value
-        navigate(`../${e.target.value}`, {replace: true})
-    }
-
     return <main>
-        <label htmlFor="category-select">Category: </label>
-        <select onChange={handleCategory} name="category" id="category-select">
-        <option value="">Show All</option>
-        {categories.map((category) => {
-            return <option key={category.slug} value={category.slug}>{category.slug}</option>
-        })}
-        </select>
+        {!selectedReview ? 
+        <>
+        <nav>
+            <ul>
+                {categories.map((category) => {
+                    return <li key={category.slug} value={category.slug}><Link to={`${category.slug}`} replace>{category.slug}</Link></li>
+                })}
+            </ul>
+        </nav>
+        
         <section>
             {reviews.map(review => {
-                return <ReviewCard key={review.review_id} title={review.title} imageURL={review.review_img_url} category={review.category} author={review.owner}/>
+                return <ReviewCard review={review} setSelectedReview={setSelectedReview} key={review.review_id} title={review.title} imageURL={review.review_img_url} category={review.category} author={review.owner}/>
             })}
         </section>
+        </>
+        : <ReviewPage selectedReview={selectedReview}/>
+        }
         
     </main>
 }

--- a/all-a-board/src/components/Main/ReviewCard.jsx
+++ b/all-a-board/src/components/Main/ReviewCard.jsx
@@ -1,7 +1,7 @@
 import './ReviewCard.css'
 
-export default function ReviewCard({title, imageURL, category, author}) {
-    return <div className="review-card">
+export default function ReviewCard({title, imageURL, category, author, setSelectedReview, review}) {
+    return <div className="review-card" onClick={() => {setSelectedReview && setSelectedReview(review)}}>
         <img src={imageURL}/>
         <div>
         <h2>{title}</h2>

--- a/all-a-board/src/components/Main/ReviewPage.jsx
+++ b/all-a-board/src/components/Main/ReviewPage.jsx
@@ -1,0 +1,7 @@
+import ReviewCard from "./ReviewCard";
+
+export default function ReviewPage({selectedReview}) {
+    return <>
+    <ReviewCard key={selectedReview.review_id} title={selectedReview.title} imageURL={selectedReview.review_img_url} category={selectedReview.category} author={selectedReview.owner}/>
+    </>
+}


### PR DESCRIPTION
(I've accidentally already pushed this to main whoops)

Implemented on this pull request:
Refactor of App:
-Introduce react router v6 functionality, initially was mapping across routes to allow for changing categories but realised this makes using links to content impossible, so they are now hardcoded

Refactor of Main:
Bring in useNavigate and useLocation hooks to allow linking to different endpoints from within a dropdown